### PR TITLE
Fix mouse bindings in spacer barlet

### DIFF
--- a/status/spacer.yaml
+++ b/status/spacer.yaml
@@ -3,5 +3,5 @@ status:
     refresh: 0
     control:
       mouse_action:
-        wheel_up: focus_next_view
-        wheel_down: focus_previous_view
+        wheel_up: focus_view_next
+        wheel_down: focus_view_previous


### PR DESCRIPTION
The mouse bindings in above barlet pointed to two non-existant methods.
This commit replaces them with the correctly named methods.

Closes #41.
